### PR TITLE
Semodule keystone

### DIFF
--- a/moc_openstack/files/keystone-all-semodule.sh
+++ b/moc_openstack/files/keystone-all-semodule.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# This script is used to create an selinux module 
+# to allow keystone to access the fernet keys
+
+# Turns selinux to permissive mode to show all potential problems,
+setenforce 0
+
+# Perform a keystone operation
+keystone token-get
+
+# Grep /var/log/audit/audit.log for the potential keystone-all access errors
+# and create an selinux module to allow access to required resources 
+grep keystone-all /var/log/audit/audit.log | audit2allow -M keystone-all
+
+# Install the selinux module
+semodule -i keystone-all.pp
+
+# Turn selinux back to enforcing
+setenforce 1
+
+# If you wish to verify the module installation,
+# run: semodule -l |grep keystone-all

--- a/moc_openstack/manifests/generate_fernet_keys.pp
+++ b/moc_openstack/manifests/generate_fernet_keys.pp
@@ -1,0 +1,17 @@
+# This module does the initial fernet key set-up
+class moc_openstack::generate_fernet_keys {
+  # Creates the directory if it does not exist
+  file { 'create_fernet_directory':
+    ensure => 'directory',
+    path  => '/etc/keystone/fernet-keys', 
+    owner => 'keystone'
+    group => 'keystone'
+    mode  => '0744',
+  }
+
+  # If the directory is empty, runs fernet key generation
+  exec { 'generate_fernet_keys':
+    command => 'source ~/keystonerc_admin; keystone-manage fernet_setup',
+    onlyif  => 'ls -A /etc/keystone/fernet-keys'
+  }
+}

--- a/moc_openstack/manifests/keystone_all_semodule.pp
+++ b/moc_openstack/manifests/keystone_all_semodule.pp
@@ -1,0 +1,15 @@
+class moc_openstack::keystone_all_semodule {
+  file { 'keystone_all_semodule':
+    ensure => 'file',
+    source => 'puppet:///modules/mymodule/keystone_all_semodule.sh',
+    path => '/usr/local/bin/keystone_all_semodule.sh',
+    owner => 'root'
+    group => 'root'
+    mode  => '0744',
+    notify => Exec['run_keystone_all_semodule'],
+  }
+  exec { 'run_keystone_all_semodule':
+    command => '/usr/local/bin/keystone_all_semodule.sh',
+    refreshonly => true,
+  }
+}

--- a/moc_openstack/manifests/keystone_all_semodule.pp
+++ b/moc_openstack/manifests/keystone_all_semodule.pp
@@ -1,15 +1,19 @@
+# This manifest creates an semodule for the keystone-all process
+# Used to permit access to fernet keys
 class moc_openstack::keystone_all_semodule {
+  # Copy the bash script to /usr/local/bin
   file { 'keystone_all_semodule':
     ensure => 'file',
-    source => 'puppet:///modules/mymodule/keystone_all_semodule.sh',
+    source => 'puppet:///modules/moc_openstack/keystone_all_semodule.sh',
     path => '/usr/local/bin/keystone_all_semodule.sh',
     owner => 'root'
     group => 'root'
     mode  => '0744',
     notify => Exec['run_keystone_all_semodule'],
   }
+  # Run the script, unless the module is installed
   exec { 'run_keystone_all_semodule':
     command => '/usr/local/bin/keystone_all_semodule.sh',
-    refreshonly => true,
+    unless  => 'semodule -l |grep keystone-all',
   }
 }

--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -789,4 +789,7 @@ class quickstack::controller_common (
   class {'quickstack::ntp':
     servers => $ntp_public_servers,
   }
+
+  class {'moc_openstack::keystone_all_semodule'}
+
 }

--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -791,7 +791,7 @@ class quickstack::controller_common (
   }
 
   # Generate fernet keys and key directory, if they do not exist
-  class {'moc_openstack::keystone_all_semodule'}
+  class {'moc_openstack::generate_fernet_keys'}
 
   # Create semodule for keystone-all access to fernet keys
   class {'moc_openstack::keystone_all_semodule'}

--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -790,6 +790,10 @@ class quickstack::controller_common (
     servers => $ntp_public_servers,
   }
 
+  # Generate fernet keys and key directory, if they do not exist
+  class {'moc_openstack::keystone_all_semodule'}
+
+  # Create semodule for keystone-all access to fernet keys
   class {'moc_openstack::keystone_all_semodule'}
 
 }

--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -791,7 +791,9 @@ class quickstack::controller_common (
   }
 
   # Generate fernet keys and key directory, if they do not exist
-  class {'moc_openstack::generate_fernet_keys'}
+  class {'moc_openstack::generate_fernet_keys':
+    require => ['quickstack::admin_client'] 
+  }
 
   # Create semodule for keystone-all access to fernet keys
   class {'moc_openstack::keystone_all_semodule'}


### PR DESCRIPTION
Two manifests are in this pull request

generate_fernet_keys:
- Creates the fernet-token directory if it does not exist, and runs keystone-manage fernet_setup if fernet-token directory is empty.

keystone-all-semodule:
- Generates semodule to allow keystone-all access to fernet-keys directory
