### PR TITLE
configure swift endpoint for rados gateway

### DIFF
--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -87,6 +87,9 @@ class quickstack::controller_common (
   $cinder_admin_url              = $quickstack::params::cinder_admin_url,
   $cinder_priv_url               = $quickstack::params::cinder_priv_url,
   $cinder_pub_url                = $quickstack::params::cinder_pub_url,
+  $swift_admin_url               = $quickstack::params::swift_admin_url,
+  $swift_priv_url                = $quickstack::params::swift_priv_url,
+  $swift_pub_url                 = $quickstack::params::swift_pub_url,
   #
 
   $glance_db_password            = $quickstack::params::glance_db_password,
@@ -373,9 +376,9 @@ class quickstack::controller_common (
 
   class { 'swift::keystone::auth':
     password         => $swift_admin_password,
-    public_address   => $controller_pub_host,
-    internal_address => $controller_priv_host,
-    admin_address    => $controller_admin_host
+    public_address   => $swift_pub_url,
+    internal_address => $swift_priv_url,
+    admin_address    => $swift_admin_url
   }
 
   class {'quickstack::glance':

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -62,7 +62,10 @@ class quickstack::params (
   $neutron_pub_url,
   $neutron_priv_url,
   $neutron_admin_url,
-  
+  # swift
+  $swift_pub_url,
+  $swift_priv_url,
+  $swift_admin_url, 
   
   # Cinder
   $cinder_db_password,

--- a/swift/manifests/keystone/auth.pp
+++ b/swift/manifests/keystone/auth.pp
@@ -102,7 +102,7 @@ class swift::keystone::auth(
   $internal_protocol      = 'http',
   $internal_address       = undef,
   $configure_endpoint     = true,
-  $configure_s3_endpoint  = true,
+  $configure_s3_endpoint  = false, 
   $endpoint_prefix        = 'AUTH',
 ) {
   $real_service_name    = pick($service_name, $auth_name)

--- a/swift/manifests/keystone/auth.pp
+++ b/swift/manifests/keystone/auth.pp
@@ -90,7 +90,7 @@ class swift::keystone::auth(
   $port                   = '8080',
   $tenant                 = 'services',
   $email                  = 'swift@localhost',
-  $region                 = 'RegionOne',
+  $region                 = $openstack::keystone::region, 
   $operator_roles         = ['admin', 'SwiftOperator'],
   $service_name           = undef,
   $service_name_s3        = undef,
@@ -138,9 +138,9 @@ class swift::keystone::auth(
     password            => $password,
     email               => $email,
     tenant              => $tenant,
-    public_url          => "${public_protocol}://${public_address}:${real_public_port}/v1/${endpoint_prefix}_%(tenant_id)s",
-    admin_url           => "${admin_protocol}://${real_admin_address}:${port}/",
-    internal_url        => "${internal_protocol}://${real_internal_address}:${port}/v1/${endpoint_prefix}_%(tenant_id)s",
+    public_url          => "${public_protocol}://${public_address}",
+    admin_url           => "${admin_protocol}://${real_admin_address}",
+    internal_url        => "${internal_protocol}://${real_internal_address}",
   }
 
   keystone::resource::service_identity { 'swift_s3':


### PR DESCRIPTION
Configured the swift endpoint to point to the radosgw.  Disable the swift_s3 endpoint which is not used.
