### PR TITLE
moved server config from top lvl manifest to moc_config

### DIFF
--- a/moc_config/manifests/server_config.pp
+++ b/moc_config/manifests/server_config.pp
@@ -1,0 +1,15 @@
+## This is the base server configuration for the Mass Open Cloud
+class moc_config::server_config() {
+
+  class { '::timezone':
+    timezone => 'America/New_York',
+  }
+
+  class { '::ssh': }
+
+  class { '::workarounds::disable_lro': }
+
+  class { '::vim': 
+    opt_misc => ['backspace=2','tabstop=4','shiftwidth=4','expandtab','nocp','relativenumber','number','ruler','hlsearch','showcmd','showmatch','ignorecase','smartcase','incsearch','autowrite','hidden']
+  }
+}

--- a/quickstack/manifests/neutron/compute.pp
+++ b/quickstack/manifests/neutron/compute.pp
@@ -276,17 +276,7 @@ class quickstack::neutron::compute (
 #    port => $ovs_vxlan_udp_port,
 #  }
 
-  class { '::timezone':
-    timezone => 'America/New_York',
-  }
-
-  class { '::ssh': }
-
-  class { '::workarounds::disable_lro': }
-
-  class { '::vim': 
-    opt_misc => ['backspace=2','tabstop=4','shiftwidth=4','expandtab','nocp','relativenumber','number','ruler','hlsearch','showcmd','showmatch','ignorecase','smartcase','incsearch','autowrite','hidden']
-  }
+  class {'moc_config::server_config'}
 
   # Security Rules fix for Openstack Instances
   sysctl::value { 'net.ipv4.conf.all.rp_filter': value => 0 }

--- a/quickstack/manifests/neutron/controller.pp
+++ b/quickstack/manifests/neutron/controller.pp
@@ -498,18 +498,8 @@ class quickstack::neutron::controller (
 #    dport    => ['9696'],
 #    action   => 'accept',
 #  }
-
-  class { '::timezone':
-    timezone => 'America/New_York',
-  }
-
-  class { '::ssh': }
-
-  class { '::workarounds::disable_lro': }
-
-  class { '::vim': 
-    opt_misc => ['backspace=2','tabstop=4','shiftwidth=4','expandtab','nocp','relativenumber','number','ruler','hlsearch','showcmd','showmatch','ignorecase','smartcase','incsearch','autowrite','hidden']
-  }
+#
+  class {'moc_config::server_config'}
 
   # Add dnsmasq-neutron.conf for MTU specification
   class {'moc_openstack::dnsmasq_neutron':


### PR DESCRIPTION
Moved the non-openstack server configuration out of neutron/[compute or controller]. Did not put sensu because sensu has a lot of openstack specific checks. Did not move the moc_openstack::firewall or ceph stuff because that is all configuring openstack specific iptables rules and ceph user&keys on the openstack nodes.
