### PR TITLE
remove class hosts from controller config

### DIFF
--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -834,9 +834,4 @@ class quickstack::controller_common (
     cron_min       => $backups_min,
   }
 
- # Create entries in /etc/hosts
- class {'hosts':
-   before  => Class['quickstack::amqp::server', 'quickstack::db::mysql'],
- }
-
 }


### PR DESCRIPTION
Class hosts should not be applied to the controller.
