### PR TITLE
Ready for merging - Sensu using private ip

### DIFF
--- a/sensu/manifests/init.pp
+++ b/sensu/manifests/init.pp
@@ -224,7 +224,7 @@ class sensu (
   $sensu_plugin_name           = 'sensu-plugin',
   $sensu_plugin_provider       = undef,
   $sensu_plugin_version        = 'present',
-  $install_repo                = true,
+  $install_repo                = false,
   $repo                        = 'main',
   $repo_source                 = undef,
   $repo_key_id                 = '8911D8FF37778F24B4E726A218609E3D7580C77F',

--- a/sensu/manifests/init.pp
+++ b/sensu/manifests/init.pp
@@ -256,7 +256,6 @@ class sensu (
   $subscriptions               = [],
   $client_bind                 = '127.0.0.1',
   $client_port                 = '3030',
-  $client_address              = $::ipaddress,
   $client_name                 = $::fqdn,
   $client_custom               = {},
   $client_keepalive            = {},
@@ -272,6 +271,12 @@ class sensu (
   $dashboard                   = false,
   $init_stop_max_wait          = 10,
 ){
+
+  if $environment == 'production' {
+    $client_address = $::ipaddress_enp130s0f0
+  } else {
+    $client_address = $::ipaddress_eth2
+  }
 
   validate_bool($client, $server, $api, $install_repo, $purge_config, $safe_mode, $manage_services, $rabbitmq_reconnect_on_error, $redis_reconnect_on_error)
 


### PR DESCRIPTION
Prior to this pull request, the sensu clients on the controller nodes were being configured with their 129 network ip addresses. Now the sensu clients on the controller nodes will be configured with their 10 network ip addresses.

Also this pull request make it so default sensu repo is not installed, because we have a separate repo server that will handle that.
