### PR TITLE
Changes for enabling resize of instances

### DIFF
--- a/quickstack/manifests/compute_common.pp
+++ b/quickstack/manifests/compute_common.pp
@@ -92,6 +92,8 @@ class quickstack::compute_common (
   $public_net                   = $quickstack::params::public_net,
   $private_net                  = $quickstack::params::private_net,
   $ntp_local_servers            = $quickstack::params::ntp_local_servers,
+  $allow_resize_to_same_host    = $quickstack::params::allow_resize,
+  $allow_migrate_to_same_host   = $quickstack::params::allow_migrate,
 ) inherits quickstack::params {
 
   if str2bool_i("$use_ssl") {
@@ -234,7 +236,9 @@ class quickstack::compute_common (
   }
 
   nova_config {
-    'DEFAULT/cinder_catalog_info': value => $cinder_catalog_info;
+    'DEFAULT/cinder_catalog_info':        value => $cinder_catalog_info;
+    'DEFAULT/allow_resize_to_same_host':  value => $allow_resize_to_same_host;
+    'DEFAULT/allow_migrate_to_same_host': value => $allow_migrate_to_same_host;
   }
 
   if $rabbit_hosts {

--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -167,6 +167,8 @@ class quickstack::controller_common (
   $public_net                    = $quickstack::params::public_net,
   $private_net                   = $quickstack::params::private_net,
   $ntp_public_servers            = $quickstack::params::ntp_public_servers,
+  $allow_resize_to_same_host     = $quickstack::params::allow_resize,
+  $allow_migrate_to_same_host    = $quickstack::params::allow_migrate,
 ) inherits quickstack::params {
 
   if str2bool_i("$use_ssl_endpoints") {
@@ -432,7 +434,9 @@ class quickstack::controller_common (
   }
 
   nova_config {
-    'DEFAULT/default_floating_pool': value => $nova_default_floating_pool;
+    'DEFAULT/default_floating_pool':      value => $nova_default_floating_pool;
+    'DEFAULT/allow_resize_to_same_host':  value => $allow_resize_to_same_host;
+    'DEFAULT/allow_migrate_to_same_host': value => $allow_migrate_to_same_host;
   }
 
   if str2bool_i("$neutron") {

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -360,5 +360,9 @@ class quickstack::params (
 
   #moc allowed users
   $moc_users,
+
+  # Allow instance resize
+  $allow_resize,
+  $allow_migrate,
 ) {
 }


### PR DESCRIPTION
This pull request contains changes required to enable resize of instances on openstack.

Changes required in hiera file:-

```
# parameters for allowing instance resize
quickstack::params::allow_resize: true
quickstack::params::allow_migrate: true
```
