### PR TITLE
let external_network_bridge be configured by user

### DIFF
--- a/quickstack/manifests/neutron/controller.pp
+++ b/quickstack/manifests/neutron/controller.pp
@@ -181,6 +181,7 @@ class quickstack::neutron::controller (
   $neutron_pub_url               = $quickstack::params::neutron_pub_url,
   $keystone_admin_url            = $quickstack::params::keystone_admin_url,
   $ovs_l2_population             = 'true',
+  $external_network_bridge       = $quickstack::params::external_network_bridge,
 ) inherits quickstack::params {
 
   if str2bool_i("$use_ssl") {

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -383,5 +383,8 @@ class quickstack::params (
   # Allow instance resize
   $allow_resize,
   $allow_migrate,
+
+  # set external_network_bridge to br-ex if only one network, else blank
+  $external_network_bridge,
 ) {
 }


### PR DESCRIPTION
Changes required in hiera file:-

```
quickstack::params::ovs_bridge_mappings: ['physext1:br-ex', 'physext2:br-ex1']
quickstack::params::ovs_bridge_uplinks: ['br-ex:ethXXX', 'br-ex1:ethYYY']
quickstack::params::external_network_bridge: ''
```

Link to a good blog for this: http://www.marcoberube.com/archives/248
