### PR TITLE
Enabling live-migration support

### DIFF
--- a/quickstack/manifests/compute_common.pp
+++ b/quickstack/manifests/compute_common.pp
@@ -231,6 +231,7 @@ class quickstack::compute_common (
       libvirt_inject_partition => -2,
       libvirt_inject_password  => $libvirt_inject_password,
       libvirt_disk_cachemodes  => ['"network=writeback"'],
+      migration_support        => true,
     }
 
     Package['nova-common'] ->


### PR DESCRIPTION
This pull-request is for enabling live-migration support. Previously, this was disabled as the default value for flag was false. I tested it on my staging environment with two nodes and things are working fine there. Here is the link used for enabling live migration:-
https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Virtualization_Deployment_and_Administration_Guide/sect-Troubleshooting-Common_libvirt_errors_and_troubleshooting.html#sect-Unable_to_connect_to_server_at_host16509_Connection_refused_..._error_failed_to_connect_to_the_hypervisor

To test the functionality:-

```
# nova list --host <compute-host-name> --all-tenants
# nova live-migration <instance-uuid> <destination-compute-host-name>
```
