### PR TITLE
nova changes for enabling instance resize openstack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@
 
 # ignore directories
 moc_openstack/files/certs
+moc_openstack/files/nova/id_rsa
+moc_openstack/files/nova/authorized_keys
 quickstack/files/backup_scripts/

--- a/moc_openstack/files/nova/config
+++ b/moc_openstack/files/nova/config
@@ -1,0 +1,3 @@
+Host *
+    StrictHostKeyChecking no
+    UserKnownHostsFile=/dev/null

--- a/moc_openstack/manifests/nova_resize.pp
+++ b/moc_openstack/manifests/nova_resize.pp
@@ -1,0 +1,38 @@
+class moc_openstack::nova_resize (
+  $nova_priv_key    = "puppet:///modules/moc_openstack/nova/id_rsa",
+  $authorized_keys  = "puppet:///modules/moc_openstack/nova/authorized_keys",
+  $nova_ssh_config  = "puppet:///modules/moc_openstack/nova/config"
+) {
+
+  exec {'enable bash for nova':
+    command => "usermod -s /bin/bash nova",
+    path    => ['/usr/bin', '/usr/sbin',],
+  } ->
+  file {'/var/lib/nova/.ssh':
+    ensure => 'directory',
+    owner  => 'nova',
+    group  => 'nova',
+    mode   => '0700',
+  } ->
+  file {'/var/lib/nova/.ssh/id_rsa':
+    ensure => present,
+    mode   => '0600',
+    owner  => 'nova',
+    group  => 'nova',
+    source => $nova_priv_key,
+  } ->
+  file {'/var/lib/nova/.ssh/authorized_keys':
+    ensure => present,
+    mode   => '0600',
+    owner  => 'nova',
+    group  => 'nova',
+    source => $authorized_keys,
+  } ->
+  file {'/var/lib/nova/.ssh/config':
+    ensure => present,
+    mode   => '644',
+    owner  => 'nova',
+    group  => 'nova',
+    source => $nova_ssh_config,
+  }
+}

--- a/quickstack/manifests/compute_common.pp
+++ b/quickstack/manifests/compute_common.pp
@@ -462,4 +462,6 @@ class quickstack::compute_common (
       auth_protocol         => $auth_protocol,
     }
   }
+
+  class {'moc_openstack::nova_resize':}
 }


### PR DESCRIPTION
Make sure one has id_rsa and authorized_keys file in moc_openstack/files/nova directory before the puppet run.

Link followed:-
https://ask.openstack.org/en/question/63999/resize-instance-ssh-warning/
