### PR TITLE
Puppetizing Sahara

### DIFF
--- a/moc_openstack/manifests/ssl/add_heat_cert.pp
+++ b/moc_openstack/manifests/ssl/add_heat_cert.pp
@@ -1,0 +1,23 @@
+class moc_openstack::ssl::add_heat_cert (
+  $heat_crt      = "/etc/pki/tls/certs/heat.crt",
+  $heat_key      = "/etc/pki/tls/private/heat.key",
+  $heat_crt_path = "puppet:///modules/moc_openstack/certs/host.crt",
+  $heat_key_path = "puppet:///modules/moc_openstack/certs/host.key",
+) {
+
+  file { $heat_crt:
+    ensure => present,
+    mode => '0644',
+    owner => 'heat',
+    group => 'heat',
+    source => $heat_crt_path,
+  }
+
+  file { $heat_key:
+    ensure => present,
+    mode => '0644',
+    owner => 'heat',
+    group => 'heat',
+    source => $heat_key_path,
+  }
+}

--- a/moc_openstack/manifests/ssl/add_heat_cert.pp
+++ b/moc_openstack/manifests/ssl/add_heat_cert.pp
@@ -7,7 +7,7 @@ class moc_openstack::ssl::add_heat_cert (
 
   file { $heat_crt:
     ensure => present,
-    mode => '0644',
+    mode => '0600',
     owner => 'heat',
     group => 'heat',
     source => $heat_crt_path,
@@ -15,7 +15,7 @@ class moc_openstack::ssl::add_heat_cert (
 
   file { $heat_key:
     ensure => present,
-    mode => '0644',
+    mode => '0600',
     owner => 'heat',
     group => 'heat',
     source => $heat_key_path,

--- a/moc_openstack/manifests/ssl/add_sahara_cert.pp
+++ b/moc_openstack/manifests/ssl/add_sahara_cert.pp
@@ -7,7 +7,7 @@ class moc_openstack::ssl::add_sahara_cert (
 
   file { $sahara_crt:
     ensure => present,
-    mode => '0644',
+    mode => '0600',
     owner => 'sahara',
     group => 'sahara',
     source => $sahara_crt_path,
@@ -15,7 +15,7 @@ class moc_openstack::ssl::add_sahara_cert (
 
   file { $sahara_key:
     ensure => present,
-    mode => '0644',
+    mode => '0600',
     owner => 'sahara',
     group => 'sahara',
     source => $sahara_key_path,

--- a/moc_openstack/manifests/ssl/add_sahara_cert.pp
+++ b/moc_openstack/manifests/ssl/add_sahara_cert.pp
@@ -1,0 +1,23 @@
+class moc_openstack::ssl::add_sahara_cert (
+  $sahara_crt      = "/etc/pki/tls/certs/sahara.crt",
+  $sahara_key      = "/etc/pki/tls/private/sahara.key",
+  $sahara_crt_path = "puppet:///modules/moc_openstack/certs/host.crt",
+  $sahara_key_path = "puppet:///modules/moc_openstack/certs/host.key",
+) {
+
+  file { $sahara_crt:
+    ensure => present,
+    mode => '0644',
+    owner => 'sahara',
+    group => 'sahara',
+    source => $sahara_crt_path,
+  }
+
+  file { $sahara_key:
+    ensure => present,
+    mode => '0644',
+    owner => 'sahara',
+    group => 'sahara',
+    source => $sahara_key_path,
+  }
+}

--- a/quickstack/manifests/compute_common.pp
+++ b/quickstack/manifests/compute_common.pp
@@ -466,9 +466,7 @@ class quickstack::compute_common (
     randomwait => 240,
   }
 
-  if !$sahara_enabled {   
-    class {'moc_openstack::suricata':
-    }
+  class {'moc_openstack::suricata':
   }
 
   if str2bool_i("$keystonerc") {

--- a/quickstack/manifests/compute_common.pp
+++ b/quickstack/manifests/compute_common.pp
@@ -11,6 +11,7 @@
 #   Defaults to the value of nova_host if unset.
 
 class quickstack::compute_common (
+  $sahara_enabled               = $quickstack::params::sahara_enabled,
   $amqp_host                    = $quickstack::params::amqp_host,
   $amqp_password                = $quickstack::params::amqp_password,
   $amqp_port                    = '5672',
@@ -464,8 +465,10 @@ class quickstack::compute_common (
     repo_server => $repo_server,
     randomwait => 240,
   }
-  
-  class {'moc_openstack::suricata':
+
+  if !$sahara_enabled {   
+    class {'moc_openstack::suricata':
+    }
   }
 
   if str2bool_i("$keystonerc") {

--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -914,9 +914,7 @@ class quickstack::controller_common (
     randomwait  => 240,
   }
 
-  if !$sahara_enabled {
-    class {'moc_openstack::suricata': }
-  }
+  class {'moc_openstack::suricata': }
 
   if hiera('moc::clusterdeployment') == 'true' {
     class {'::galera::server':

--- a/quickstack/manifests/db/mysql.pp
+++ b/quickstack/manifests/db/mysql.pp
@@ -109,6 +109,7 @@ class quickstack::db::mysql (
                     'ssl-ca'         => $mysql_ca,
                     'ssl-cert'       => $mysql_cert,
                     'ssl-key'        => $mysql_key,
+                    'max_allowed_packet' => '256M',
       },
     },
     root_password => $mysql_root_password,

--- a/quickstack/manifests/heat_controller.pp
+++ b/quickstack/manifests/heat_controller.pp
@@ -1,4 +1,5 @@
 class quickstack::heat_controller(
+  $sahara_enabled = $quickstack::params::sahara_enabled,
   $auth_encryption_key,
   $heat_cfn,
   $heat_cloudwatch,
@@ -66,11 +67,22 @@ class quickstack::heat_controller(
       enabled => str2bool_i("$heat_cloudwatch"),
   }
 
-  class { '::heat::engine':
+  if $sahara_enabled {
+    class { '::heat::engine':
+      auth_encryption_key             => $auth_encryption_key,
+      heat_metadata_server_url        => "http://${controller_priv_host}:8000",
+      heat_waitcondition_server_url   => "http://${controller_priv_host}:8000/v1/waitcondition",
+      heat_watch_server_url           => "http://${controller_priv_host}:8003",
+      trusts_delegated_roles           => [''],
+      configure_delegated_roles       => false,
+    }
+  } else {
+    class { '::heat::engine':
       auth_encryption_key           => $auth_encryption_key,
       heat_metadata_server_url      => "http://${controller_priv_host}:8000",
       heat_waitcondition_server_url => "http://${controller_priv_host}:8000/v1/waitcondition",
       heat_watch_server_url         => "http://${controller_priv_host}:8003",
+     }
   }
 
   # TODO: this ain't no place to be creating a db locally as happens below

--- a/quickstack/manifests/heat_controller.pp
+++ b/quickstack/manifests/heat_controller.pp
@@ -19,10 +19,16 @@ class quickstack::heat_controller(
   $amqp_password,
   $verbose,
   $heat_use_ssl = $quickstack::params::use_ssl_endpoints,
+  $heat_key = $quickstack::params::heat_key,
+  $heat_controller = $quickstack::params::heat_cert,
 ) {
 
   if ($heat_use_ssl) {
       class {'moc_openstack::ssl::add_heat_cert':
+      }
+      heat_config {
+        'ssl/key_file': value => $heat_key;
+        'ssl/cert_file': value => $heat_cert;
       }
   }
 

--- a/quickstack/manifests/heat_controller.pp
+++ b/quickstack/manifests/heat_controller.pp
@@ -55,6 +55,9 @@ class quickstack::heat_controller(
       public_address   => $controller_pub_host,
       admin_address    => $controller_priv_host,
       internal_address => $controller_priv_host,
+      public_protocol  => $heat_endpoint_protocol,
+      internal_protocol => $heat_endpoint_protocol,
+      admin_protocol   => $heat_endpoint_protocol,
   }
 
   class { '::heat':

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -418,6 +418,5 @@ class quickstack::params (
   $sahara_debug,
   $heat_domain_password,
   $sahara_plugins,
-  $sahara_use_ssl,
 ) {
 }

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -409,7 +409,7 @@ class quickstack::params (
   $ceilometer_keystone_user,
   $ceilometer_keystone_tenant,
   $ceilometer_rabbit_port,
-  $ceilometer_auth_url
+  $ceilometer_auth_url,
 
   # Sahara
   $sahara_enabled,

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -410,5 +410,13 @@ class quickstack::params (
   $ceilometer_keystone_tenant,
   $ceilometer_rabbit_port,
   $ceilometer_auth_url
+
+  # Sahara
+  $sahara_enabled,
+  $sahara_password,
+  $sahara_db_password,
+  $sahara_debug,
+  $heat_domain_password,
+  $sahara_plugins,
 ) {
 }

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -216,6 +216,10 @@ class quickstack::params (
   $glance_cert,
   $neutron_key,
   $neutron_cert,
+  $heat_key,
+  $heat_cert,
+  $sahara_key,
+  $sahara_cert,
 
   # neutron plugin config
   $neutron_core_plugin,

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -418,5 +418,6 @@ class quickstack::params (
   $sahara_debug,
   $heat_domain_password,
   $sahara_plugins,
+  $sahara_use_ssl,
 ) {
 }

--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -12,6 +12,8 @@ class quickstack::sahara (
   $rabbit_password = $quickstack::params::amqp_password,
   $hostname = $quickstack::params::controller_admin_host,
   $sahara_use_ssl = $quickstack::params::use_ssl_endpoints,
+  $sahara_key = $quickstack::params::sahara_key,
+  $sahara_cert = $quickstack::params::sahara_cert,
 ) {
   
   if ($sahara_use_ssl) {
@@ -43,6 +45,11 @@ class quickstack::sahara (
   sahara_config {
     'DEFAULT/heat_enable_wait_condition': value => false;
     'DEFAULT/plugins': value => $sahara_plugins;
+  }
+  
+  sahara_config {
+    'ssl/key_file': value => $sahara_key;
+    'ssl/cert_file': value => $sahara_cert;
   }
 
   if $sahara_use_ssl {

--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -1,0 +1,65 @@
+class quickstack::sahara (
+  $sahara_password = $quickstack::params::sahara_password,
+  $sahara_db_password = $quickstack::params::sahara_db_password,
+  $sahara_debug = $quickstack::params::sahara_debug,
+  $heat_domain_password = $quickstack::params::heat_domain_password,
+  $sahara_plugins = $quickstack::params::sahara_plugins,
+  $keystone_auth_uri = "${quickstack::params::auth_uri}v2.0/",
+  $keystone_identity_uri = $quickstack::params::identity_uri,
+  $keystone_tenant_name = 'services',
+  $keystone_region_name = $openstack::keystone::region,
+  $rabbit_userid = $quickstack::params::amqp_username,
+  $rabbit_password = $quickstack::params::amqp_password,
+  $hostname = $quickstack::params::controller_admin_host,
+) {
+
+  class { '::sahara::db::mysql':
+    password => $sahara_db_password,
+    host     => 'localhost',
+  }
+
+  class { '::sahara':
+    database_connection => "mysql://sahara:${sahara_db_password}@localhost:3306/sahara",
+    debug               => $sahara_debug,
+    log_dir             => '/var/log/sahara',
+    use_neutron         => true,
+    keystone_username   => 'sahara',
+    keystone_password   => $sahara_password,
+    keystone_tenant     => $keystone_tenant_name,
+    keystone_url        => $keystone_auth_uri,
+    identity_url        => $keystone_identity_uri,
+    service_host        => '0.0.0.0',
+    service_port        => 8386,
+    use_floating_ips    => true,
+  }
+
+  sahara_config {
+    'DEFAULT/heat_enable_wait_condition': value => false;
+    'DEFAULT/plugins': value => $sahara_plugins;
+  }
+
+  class { '::sahara::keystone::auth':
+    password     => $sahara_password,
+    auth_name    => 'sahara',
+    tenant       => $keystone_tenant_name,
+    region       => $keystone_region_name,
+    public_url   => "http://${hostname}:8386/v1.1/%(tenant_id)s",
+    admin_url    => "http://${hostname}:8386/v1.1/%(tenant_id)s", 
+    internal_url => "http://${hostname}:8386/v1.1/%(tenant_id)s",
+  }
+
+  class { '::sahara::notify::rabbitmq':
+    rabbit_userid   => $rabbit_userid,
+    rabbit_password => $rabbit_password,
+  }
+
+  class { '::heat::keystone::domain':
+    auth_url          => $keystone_auth_uri,
+    keystone_admin    => 'admin',
+    keystone_password => $quickstack::params::admin_password,
+    keystone_tenant   => 'admin',
+    domain_password   => $heat_domain_password
+  }
+
+
+}

--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -16,7 +16,7 @@ class quickstack::sahara (
   $sahara_cert = $quickstack::params::sahara_cert,
 ) {
   
-  if ($sahara_use_ssl) {
+  if str2bool_i($sahara_use_ssl) {
       class {'moc_openstack::ssl::add_sahara_cert':
       }
     }
@@ -52,7 +52,7 @@ class quickstack::sahara (
     'ssl/cert_file': value => $sahara_cert;
   }
 
-  if $sahara_use_ssl {
+  if str2bool_i($sahara_use_ssl) {
     $endpoint_url = "https://${hostname}:8386/v1.1/%(tenant_id)s"
   } else {
     $endpoint_url = "http://${hostname}:8386/v1.1/%(tenant_id)s"

--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -30,7 +30,7 @@ class quickstack::sahara (
     identity_url        => $keystone_identity_uri,
     service_host        => '0.0.0.0',
     service_port        => 8386,
-    use_floating_ips    => true,
+    use_floating_ips    => false,
   }
 
   sahara_config {

--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -11,7 +11,7 @@ class quickstack::sahara (
   $rabbit_userid = $quickstack::params::amqp_username,
   $rabbit_password = $quickstack::params::amqp_password,
   $hostname = $quickstack::params::controller_admin_host,
-  $sahara_use_ssl = $quickstack::params::sahara_use_ssl,
+  $sahara_use_ssl = $quickstack::params::use_ssl_endpoints,
 ) {
   
   if ($sahara_use_ssl) {


### PR DESCRIPTION
Enable and configure Sahara, and create the required Heat domain. Additionally, increase maximum packet size in MySQL so we can store Sahara jobs. Also take note that if sahara_enabled=true then Suricata will be disabled so that Sahara can communicate to its instances.
