### PR TITLE
Sahara DB changes

### DIFF
--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -193,7 +193,8 @@ class quickstack::controller_common (
   $allow_migrate_to_same_host    = $quickstack::params::allow_migrate,
   $repo_server                   = $quickstack::params::repo_server,
   $elasticsearch_host            = $quickstack::params::elasticsearch_host,
-  $enable_ceilometer             = $quickstack::params::enable_ceilometer
+  $enable_ceilometer             = $quickstack::params::enable_ceilometer,
+  $sahara_db_password            = $quickstack::params::sahara_db_password,
 ) inherits quickstack::params {
 
   if str2bool_i("$use_ssl_endpoints") {
@@ -301,6 +302,7 @@ class quickstack::controller_common (
     nova_db_password     => $nova_db_password,
     cinder_db_password   => $cinder_db_password,
     neutron_db_password  => $neutron_db_password,
+    sahara_db_password   => $sahara_db_password,
 
     # MySQL
     mysql_bind_address     => '0.0.0.0',

--- a/quickstack/manifests/db/mysql.pp
+++ b/quickstack/manifests/db/mysql.pp
@@ -63,6 +63,8 @@ class quickstack::db::mysql (
     $cinder_db_password,
     $neutron_db_password,
     $ceilometer_db_password = false,
+    $sahara_db_password,
+    $
     # MySQL
     $mysql_bind_address     = '0.0.0.0',
     $mysql_account_security = true,
@@ -92,6 +94,10 @@ class quickstack::db::mysql (
     $ceilometer             = false,
     $ceilometer_db_user     = 'ceilometer',
     $ceilometer_db_dbname   = 'ceilometer',
+    # Sahara
+    $sahara                 = $quickstack::params::sahara_enabled,
+    $sahara_db_user         = 'sahara',
+    $sahara_db_dbname       = 'sahara',
     # General
     $allowed_hosts          = false,
     $charset                = 'utf8',
@@ -181,5 +187,16 @@ class quickstack::db::mysql (
         charset       => $charset,
       }
     }
+
+    if ($sahara) {
+      class { '::sahara::db::mysql':
+        user          => $sahara_db_user,
+        password      => $sahara_db_password,
+        dbname        => $sahara_db_dbname,
+        allowed_hosts => $allowed_hosts,
+        charset       => $charset,
+      }
+1    }
+
   }
 }

--- a/quickstack/manifests/db/mysql.pp
+++ b/quickstack/manifests/db/mysql.pp
@@ -195,7 +195,7 @@ class quickstack::db::mysql (
         allowed_hosts => $allowed_hosts,
         charset       => $charset,
       }
-1    }
+    }
 
   }
 }

--- a/quickstack/manifests/db/mysql.pp
+++ b/quickstack/manifests/db/mysql.pp
@@ -64,7 +64,6 @@ class quickstack::db::mysql (
     $neutron_db_password,
     $ceilometer_db_password = false,
     $sahara_db_password,
-    $
     # MySQL
     $mysql_bind_address     = '0.0.0.0',
     $mysql_account_security = true,

--- a/quickstack/manifests/db/mysql.pp
+++ b/quickstack/manifests/db/mysql.pp
@@ -177,7 +177,7 @@ class quickstack::db::mysql (
       }
     }
 
-    if ($ceilometer) {
+    if (str2bool_i($ceilometer)) {
       class { '::ceilometer::db::mysql':
         user          => $ceilometer_db_user,
         password      => $ceilometer_db_password,
@@ -187,7 +187,7 @@ class quickstack::db::mysql (
       }
     }
 
-    if ($sahara) {
+    if (str2bool_i($sahara)) {
       class { '::sahara::db::mysql':
         user          => $sahara_db_user,
         password      => $sahara_db_password,

--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -21,14 +21,7 @@ class quickstack::sahara (
       }
     }
 
-
-  class { '::sahara::db::mysql':
-    password => $sahara_db_password,
-    host     => 'localhost',
-  }
-
   class { '::sahara':
-    database_connection => "mysql://sahara:${sahara_db_password}@localhost:3306/sahara",
     debug               => $sahara_debug,
     log_dir             => '/var/log/sahara',
     use_neutron         => true,


### PR DESCRIPTION
Make Sahara's DB creation process the same as the rest of the services. Changes to Hiera file:  

```
quickstack::db::mysql::sahara_db_user: 'moc_sahara'  
quickstack::db::mysql::sahara_db_dbname: 'moc_kaizen_sahara'  
sahara::database_connection: "mysql://moc_sahara:PASSWORD@controller-0.kaizen.massopencloud.org/moc_kaizen_sahara"  
```

`quickstack::params::sahara_db_password` was already added during the previous iteration, but take note to make sure it matches your other parameters.
