### PR TITLE
Enable namespaces and rootwrap for Sahara

### DIFF
--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -37,9 +37,9 @@ class quickstack::sahara (
 
   sahara_config {
     'DEFAULT/heat_enable_wait_condition': value => false;
-    'DEFAULT/plugins': value => $sahara_plugins;
-    'DEFAULT/use_namespaces': value => true;
-    'DEFAULT/use_rootwrap': value => true;
+    'DEFAULT/plugins':                    value => $sahara_plugins;
+    'DEFAULT/use_namespaces':             value => true;
+    'DEFAULT/use_rootwrap':               value => true;
   }
   
   sahara_config {

--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -38,6 +38,8 @@ class quickstack::sahara (
   sahara_config {
     'DEFAULT/heat_enable_wait_condition': value => false;
     'DEFAULT/plugins': value => $sahara_plugins;
+    'DEFAULT/use_namespaces': value => true;
+    'DEFAULT/use_rootwrap': value => true;
   }
   
   sahara_config {


### PR DESCRIPTION
Configure the Sahara service to use Neutron namespaces, and rootwrap, in order to access instances over internal/private IP.
