### PR TITLE
Changes which service logs Filebeat collects, and add tags

### DIFF
--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -193,7 +193,6 @@ class quickstack::controller_common (
   $allow_migrate_to_same_host    = $quickstack::params::allow_migrate,
   $repo_server                   = $quickstack::params::repo_server,
   $elasticsearch_host            = $quickstack::params::elasticsearch_host,
-  $logstash_host                 = $quickstack::params::logstash_host,
   $enable_ceilometer             = $quickstack::params::enable_ceilometer,
   $sahara_db_password            = $quickstack::params::sahara_db_password,
 ) inherits quickstack::params {
@@ -900,7 +899,7 @@ class quickstack::controller_common (
   class { 'filebeat':
     outputs => {
       'logstash'  => {
-	'hosts'        =>  [$logstash_host],
+	'hosts'        =>  [$elasticsearch_host],
 	'loadbalance' => true
       }
     },

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -395,6 +395,7 @@ class quickstack::params (
   $backups_enabled,
 
   $elasticsearch_host,
+  $logstash_host,
 
   # Allow instance resize
   $allow_resize,

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -395,7 +395,6 @@ class quickstack::params (
   $backups_enabled,
 
   $elasticsearch_host,
-  $logstash_host,
 
   # Allow instance resize
   $allow_resize,


### PR DESCRIPTION
Modified the Filebeat configuration in the openstack controller node. Let Filebeat collect different log files from openstack services and also add tags on them.
