### PR TITLE
Sahara: Fix adding of libs for MapReduce jobs in UI

### DIFF
--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -209,6 +209,13 @@ class quickstack::sahara (
     after   => '        curr_extra = job_execution.extra.copy()',
   }
 
+  file_line { 'mr_job':
+    notify  => Service['httpd'],
+    path    => '/usr/share/openstack-dashboard/openstack_dashboard/contrib/sahara/content/data_processing/jobs/workflows/create.py',
+    line    => "                'data-jobtype-mapreduce': (\"Choose libraries\"),",
+    after   => "                'data-jobtype-java': _\u0028\"Choose libraries\"\u0029,"
+  }
+
   #file_line { 'disable_floating':
   #  notify  => Service['httpd'], # only restarts if a file changes
   #  path    => '/etc/openstack-dashboard/local_settings',

--- a/quickstack/manifests/sahara.pp
+++ b/quickstack/manifests/sahara.pp
@@ -212,7 +212,7 @@ class quickstack::sahara (
   file_line { 'mr_job':
     notify  => Service['httpd'],
     path    => '/usr/share/openstack-dashboard/openstack_dashboard/contrib/sahara/content/data_processing/jobs/workflows/create.py',
-    line    => "                'data-jobtype-mapreduce': (\"Choose libraries\"),",
+    line    => "                'data-jobtype-mapreduce': _(\"Choose libraries\"),",
     after   => "                'data-jobtype-java': _\u0028\"Choose libraries\"\u0029,"
   }
 


### PR DESCRIPTION
It turns out there was one more bug in Sahara that I didn't catch until now. This PR fixes the Sahara dashboard to allow the adding of libs for MapReduce jobs. The bugfix will not be necessary when we upgrade to Mitaka.
