### PR TITLE
temporarily disable migration in 1new-kernel-reboot script.

### DIFF
--- a/moc_openstack/templates/1new-kernel-reboot.erb
+++ b/moc_openstack/templates/1new-kernel-reboot.erb
@@ -18,7 +18,7 @@ if [ "$role" == "compute" ]; then
   [ "`rpm -q kernel|tail -n 1|cut -d l -f 2`" != "-`uname -r|cut -d l -f 1`" ] || exit
   . /root/keystonerc_admin
   [ "`nova hypervisor-list|wc -l`" == "5"  ] && reboot
-  nova host-servers-migrate $hst > /dev/null
+#  nova host-servers-migrate $hst > /dev/null
   nova host-evacuate-live $hst > /dev/null
   while [ "`virsh list|wc -l`" != "3" ]; do
     sleep 1


### PR DESCRIPTION
The instance gets stuck waiting for user confirmation.
