### PR TITLE
Sensu parameters

### DIFF
--- a/quickstack/manifests/compute_common.pp
+++ b/quickstack/manifests/compute_common.pp
@@ -91,7 +91,14 @@ class quickstack::compute_common (
   $sensu_rabbitmq_user          = $quickstack::params::sensu_rabbitmq_user,
   $sensu_rabbitmq_password      = $quickstack::params::sensu_rabbitmq_password,
   $sensu_client_subscriptions   = $quickstack::params::sensu_subscriptions_compute,
-  $sensu_client_keepalive       = { "thresholds" => { "warning" => 60, "critical" => 300 }, "handlers" => $quickstack::params::sensu_handlers_compute, "refresh" => 3600 },
+  $sensu_client_keepalive       = { 
+                                    "thresholds" => { 
+                                      "warning"  => 60, 
+                                      "critical" => 300 
+                                    }, 
+                                    "handlers"   => $quickstack::params::sensu_handlers_compute, 
+                                    "refresh" => 3600 
+                                  },
   $public_net                   = $quickstack::params::public_net,
   $private_net                  = $quickstack::params::private_net,
   $ntp_local_servers            = $quickstack::params::ntp_local_servers,
@@ -102,7 +109,7 @@ class quickstack::compute_common (
   $backups_script_local         = $quickstack::params::backups_script_local_name,
   $backups_dir                  = $quickstack::params::backups_directory,
   $backups_log                  = $quickstack::params::backups_log,
-  $backups_verbose		        = $quickstack::params::backups_verbose,
+  $backups_verbose              = $quickstack::params::backups_verbose,
   $backups_email                = $quickstack::params::backups_email,
   $backups_ssh_key              = $quickstack::params::backups_ssh_key,
   $backups_sudoers_d            = $quickstack::params::backups_sudoers_d,

--- a/quickstack/manifests/compute_common.pp
+++ b/quickstack/manifests/compute_common.pp
@@ -86,11 +86,12 @@ class quickstack::compute_common (
   $rbd_key                      = $quickstack::params::rbd_key,
   $ceph_iface                   = $quickstack::params::ceph_iface,
   $ceph_vlan                    = $quickstack::params::ceph_vlan,
+  $sensu_client_enable          = $quickstack::params::sensu_client_enable,
   $sensu_rabbitmq_host          = $quickstack::params::sensu_rabbitmq_host,
   $sensu_rabbitmq_user          = $quickstack::params::sensu_rabbitmq_user,
   $sensu_rabbitmq_password      = $quickstack::params::sensu_rabbitmq_password,
-  $sensu_client_subscriptions_compute = 'moc-sensu',
-  $sensu_client_keepalive       = { "thresholds" => { "warning" => 60, "critical" => 300 }, "handlers" => ["node-email"], "refresh" => 3600 },
+  $sensu_client_subscriptions   = $quickstack::params::sensu_subscriptions_compute,
+  $sensu_client_keepalive       = { "thresholds" => { "warning" => 60, "critical" => 300 }, "handlers" => $quickstack::params::sensu_handlers_compute, "refresh" => 3600 },
   $public_net                   = $quickstack::params::public_net,
   $private_net                  = $quickstack::params::private_net,
   $ntp_local_servers            = $quickstack::params::ntp_local_servers,
@@ -389,7 +390,9 @@ class quickstack::compute_common (
     ensure => latest,
   }
 #Customization for configuring sensu
+
   class { '::sensu':
+    client                => $sensu_client_enable,
     sensu_plugin_name     => 'sensu-plugin',
     sensu_plugin_version  => 'installed',
     sensu_plugin_provider => 'gem',
@@ -398,7 +401,7 @@ class quickstack::compute_common (
     rabbitmq_user         => $sensu_rabbitmq_user,
     rabbitmq_password     => $sensu_rabbitmq_password,
     rabbitmq_vhost        => '/sensu',
-    subscriptions         => $sensu_client_subscriptions_compute,
+    subscriptions         => $sensu_client_subscriptions,
     client_keepalive      => $sensu_client_keepalive,
     plugins               => [
        "puppet:///modules/sensu/plugins/check-mem.sh",
@@ -420,6 +423,7 @@ class quickstack::compute_common (
     ]
   }
   
+
   class {'quickstack::ntp':
     servers => $ntp_local_servers,
   }

--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -157,7 +157,14 @@ class quickstack::controller_common (
   $sensu_rabbitmq_user           = $quickstack::params::sensu_rabbitmq_user,
   $sensu_rabbitmq_password       = $quickstack::params::sensu_rabbitmq_password,
   $sensu_client_subscriptions    = $quickstack::params::sensu_subscriptions_controller,
-  $sensu_client_keepalive       = { "thresholds" => { "warning" => 60, "critical" => 300 }, "handlers" => $quickstack::params::sensu_handlers_controller, "refresh" => 3600 },
+  $sensu_client_keepalive        = { 
+                                     "thresholds" => {
+                                       "warning"  => 60, 
+                                       "critical" => 300 
+                                     }, 
+                                     "handlers"   => $quickstack::params::sensu_handlers_controller, 
+                                     "refresh"    => 3600 
+                                   },
   $ceph_key                      = $quickstack::params::ceph_key,
   $use_ssl_endpoints             = $quickstack::params::use_ssl_endpoints,
   $neutron_admin_password        = $quickstack::params::neutron_user_password,
@@ -821,18 +828,18 @@ class quickstack::controller_common (
   }
 #Customization for isntalling sensu
   class { '::sensu':
-    client => $sensu_client_enable,            
-    sensu_plugin_name => 'sensu-plugin',
-    sensu_plugin_version => 'installed',
+    client                => $sensu_client_enable,            
+    sensu_plugin_name     => 'sensu-plugin',
+    sensu_plugin_version  => 'installed',
     sensu_plugin_provider => 'gem',
-    purge_config => true,
-    rabbitmq_host => $sensu_rabbitmq_host,
-    rabbitmq_user => $sensu_rabbitmq_user,
-    rabbitmq_password => $sensu_rabbitmq_password,
-    rabbitmq_vhost => '/sensu',
-    subscriptions => $sensu_client_subscriptions,
+    purge_config          => true,
+    rabbitmq_host         => $sensu_rabbitmq_host,
+    rabbitmq_user         => $sensu_rabbitmq_user,
+    rabbitmq_password     => $sensu_rabbitmq_password,
+    rabbitmq_vhost        => '/sensu',
+    subscriptions         => $sensu_client_subscriptions,
     client_keepalive      => $sensu_client_keepalive,
-    plugins       => [
+    plugins               => [
        "puppet:///modules/sensu/plugins/check-mem.sh",
        "puppet:///modules/sensu/plugins/cpu-metrics.rb",
        "puppet:///modules/sensu/plugins/disk-usage-metrics.rb",

--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -152,11 +152,12 @@ class quickstack::controller_common (
   $ceph_enpoints                 = $quickstack::params::ceph_endpoints,
   $ceph_user                     = $quickstack::params::ceph_user,
   $ceph_vlan                     = $quickstack::params::ceph_vlan,
+  $sensu_client_enable           = $quickstack::params::sensu_client_enable,
   $sensu_rabbitmq_host           = $quickstack::params::sensu_rabbitmq_host,
   $sensu_rabbitmq_user           = $quickstack::params::sensu_rabbitmq_user,
   $sensu_rabbitmq_password       = $quickstack::params::sensu_rabbitmq_password,
-  $sensu_client_subscriptions_controller   = 'moc-sensu',
-  $sensu_client_keepalive       = { "thresholds" => { "warning" => 60, "critical" => 300 }, "handlers" => ["node-email"], "refresh" => 3600 },
+  $sensu_client_subscriptions    = $quickstack::params::sensu_subscriptions_controller,
+  $sensu_client_keepalive       = { "thresholds" => { "warning" => 60, "critical" => 300 }, "handlers" => $quickstack::params::sensu_handlers_controller, "refresh" => 3600 },
   $ceph_key                      = $quickstack::params::ceph_key,
   $use_ssl_endpoints             = $quickstack::params::use_ssl_endpoints,
   $neutron_admin_password        = $quickstack::params::neutron_user_password,
@@ -820,6 +821,7 @@ class quickstack::controller_common (
   }
 #Customization for isntalling sensu
   class { '::sensu':
+    client => $sensu_client_enable,            
     sensu_plugin_name => 'sensu-plugin',
     sensu_plugin_version => 'installed',
     sensu_plugin_provider => 'gem',
@@ -828,7 +830,7 @@ class quickstack::controller_common (
     rabbitmq_user => $sensu_rabbitmq_user,
     rabbitmq_password => $sensu_rabbitmq_password,
     rabbitmq_vhost => '/sensu',
-    subscriptions => $sensu_client_subscriptions_controller,
+    subscriptions => $sensu_client_subscriptions,
     client_keepalive      => $sensu_client_keepalive,
     plugins       => [
        "puppet:///modules/sensu/plugins/check-mem.sh",

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -362,9 +362,14 @@ class quickstack::params (
   $gluster_volume3_uid,
 
   # sensu server
+  $sensu_client_enable,
   $sensu_rabbitmq_host,
   $sensu_rabbitmq_user,
   $sensu_rabbitmq_password,
+  $sensu_subscriptions_compute,
+  $sensu_subscriptions_controller,
+  $sensu_handlers_compute,
+  $sensu_handlers_controller,
 
   # Firewall
   $public_net,


### PR DESCRIPTION
Enable/disable Sensu and specify subscriptions or handlers in the hiera file.  

Among other things, this will allow staging and research nodes deployed from this code to turn off emails to the ops team mailing list, or turn off Sensu entirely and prevent extraneous clients from registering with the Sensu server.

I also cleaned up some formatting (for sensu-related lines only). 

New hiera variables (and suggested values):

quickstack::params::sensu_client_enable = true
quickstack::params::sensu_subscriptions_compute
quickstack::params::sensu_subscriptions_controller
quickstack::params::sensu_handlers_compute
quickstack::params::sensu_handlers_controller 

In staging, both handler values should be set to a handler that does not email the ops team.

This has been tested for error-free deployment in staging.  Doesn't need Tempest testing as we are not actually changing the operation of Sensu, just how we specify some of the config.
