### PR TITLE
Sensu redact vinay

### DIFF
--- a/quickstack/manifests/controller_common.pp
+++ b/quickstack/manifests/controller_common.pp
@@ -838,6 +838,8 @@ class quickstack::controller_common (
     rabbitmq_password     => $sensu_rabbitmq_password,
     rabbitmq_vhost        => '/sensu',
     subscriptions         => $sensu_client_subscriptions,
+    redact                => $redact,
+    client_custom         => $client_custom,
     client_keepalive      => $sensu_client_keepalive,
     plugins               => [
        "puppet:///modules/sensu/plugins/check-mem.sh",

--- a/quickstack/manifests/params.pp
+++ b/quickstack/manifests/params.pp
@@ -370,6 +370,8 @@ class quickstack::params (
   $sensu_subscriptions_controller,
   $sensu_handlers_compute,
   $sensu_handlers_controller,
+  $redact,
+  $client_custom,
 
   # Firewall
   $public_net,

--- a/sensu/lib/puppet/provider/sensu_client_config/json.rb
+++ b/sensu/lib/puppet/provider/sensu_client_config/json.rb
@@ -51,7 +51,7 @@ Puppet::Type.type(:sensu_client_config).provide(:json) do
   end
 
   def check_args
-    ['name', 'address', 'subscriptions', 'safe_mode', 'bind', 'keepalive', 'port']
+    ['name', 'address', 'subscriptions', 'safe_mode', 'bind', 'keepalive', 'port', 'redact']
   end
 
   def client_name
@@ -93,7 +93,15 @@ Puppet::Type.type(:sensu_client_config).provide(:json) do
   def subscriptions=(value)
     conf['client']['subscriptions'] = value
   end
+  
+  def redact
+    conf['client']['redact'] || []
+  end
 
+  def redact=(value)
+    conf['client']['redact'] = value
+  end
+  
   def custom
     conf['client'].reject { |k,v| check_args.include?(k) }
   end

--- a/sensu/lib/puppet/type/sensu_client_config.rb
+++ b/sensu/lib/puppet/type/sensu_client_config.rb
@@ -47,6 +47,13 @@ Puppet::Type.newtype(:sensu_client_config) do
       is.sort == should.sort
     end
   end
+  
+  newproperty(:redact, :array_matching => :all) do
+    desc "An array of strings that should be redacted in the sensu client config"
+    def insync?(is)
+      is.sort == should.sort
+    end
+  end
 
   newproperty(:bind) do
     desc "The IP that client will bind to"

--- a/sensu/manifests/client/config.pp
+++ b/sensu/manifests/client/config.pp
@@ -31,6 +31,7 @@ class sensu::client::config {
     safe_mode     => $sensu::safe_mode,
     custom        => $sensu::client_custom,
     keepalive     => $sensu::client_keepalive,
+    redact        => $sensu::redact,
   }
 
 }

--- a/sensu/manifests/init.pp
+++ b/sensu/manifests/init.pp
@@ -269,6 +269,7 @@ class sensu (
   $gem_path                    = '',
   $log_level                   = 'info',
   $dashboard                   = false,
+  $redact                      = undef,
   $init_stop_max_wait          = 10,
 ){
 

--- a/sensu/spec/classes/sensu_client_spec.rb
+++ b/sensu/spec/classes/sensu_client_spec.rb
@@ -16,6 +16,7 @@ describe 'sensu', :type => :class do
           :bind          => '127.0.0.1',
           :port          => '3030',
           :subscriptions => [],
+          :redact        => [],
           :ensure        => 'present',
           :custom        => {}
         ) }
@@ -26,6 +27,7 @@ describe 'sensu', :type => :class do
           :client                   => true,
           :client_address           => '1.2.3.4',
           :subscriptions            => ['all'],
+          :redact                   => ['password'],
           :client_name              => 'myclient',
           :safe_mode                => true,
           :client_custom            => { 'bool' => true, 'foo' => 'bar' }
@@ -38,6 +40,7 @@ describe 'sensu', :type => :class do
           :bind          => '127.0.0.1',
           :port          => '3030',
           :subscriptions => ['all'],
+          :redact        => ['password'],
           :ensure        => 'present',
           :safe_mode     => true,
           :custom        => { 'bool' => true, 'foo' => 'bar' }


### PR DESCRIPTION
Added redact to the sensu-puppet, modified the controller_common.pp, params.pp of test_private environment to support redact. Added redact and password fields in the /var/lib/hiera/test_private.yaml 
