### PR TITLE
write integers to sensu client.json as integers, not strings

### DIFF
--- a/sensu/lib/puppet/provider/sensu_client_config/json.rb
+++ b/sensu/lib/puppet/provider/sensu_client_config/json.rb
@@ -108,7 +108,7 @@ Puppet::Type.type(:sensu_client_config).provide(:json) do
   end
 
   def keepalive=(value)
-    conf['client']['keepalive'] = value
+    conf['client']['keepalive'] = to_type(value)
   end
 
   def safe_mode


### PR DESCRIPTION
Sensu-client currently fails to start on a fresh deployment because /etc/sensu/conf.d/client.json is formatted incorrectly, with keepalive values that should be integers encased in quotes.  

What happens now:

```
"keepalive": {
  "thresholds": {
    "warning": "60",
      "critical": "300"
  },
  "handlers": [
    "default"
  ],  
  "refresh": "3600"
}
```

What happens after this PR:

```
"keepalive": {
  "thresholds": {
    "warning": 60,
      "critical": 300
  },
  "handlers": [
    "default"
  ],  
  "refresh": 3600
}
```

Here is a related commit in the main sensu-puppet repo:
https://github.com/sensu/sensu-puppet/commit/4f736d3b01d8a4f3c78ba56fd16d94a21db8c2db

Much of what was changed in the link above seems to already be implemented in our code, but we were missing this change.  We may want to go through the code at the link above in order to check for any other cases where this is happening under the radar.

This update has been tested in a fresh staging-area deployment, but I did not run tempest.  I can if you would like.
